### PR TITLE
Add feature back in to accept text commands

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ const discordUserAnnouncementDictionary: { [key: string]: string } = {
 // Event triggered when a message is sent in a text channel
 client.on('messageCreate', async (message) => {
   // Commands are represented by a '!'
-  if (message.content.charAt(0) == '!') {
+  if (message.content.charAt(0) === '!') {
     const userCommand = message.content.split('!')[1].toLowerCase();
     channel = message.member?.voice.channel as VoiceBasedChannel;
 
@@ -101,9 +101,9 @@ client.on('messageCreate', async (message) => {
           connection?.destroy();
         }
       } else {
-        fs.readdir('./clips', function(err, files) {
-          files.forEach(function(file, index) {
-              if (file.split(".")[0] == userCommand) {
+        fs.readdir('./clips', (err, files) => {
+          files.forEach((file, index) => {
+              if (file.split(".")[0] === userCommand) {
                 playClip(file, channel, audioPlayer);
               }
           });


### PR DESCRIPTION
This PR adds back in the ability to accept and process text commands to play clips.

**NOTE**: the Discord API has a [Slash Command API](https://discordjs.guide/creating-your-bot/slash-commands.html#before-you-continue) that should replace this.. this is meant just to get the functionality working again. I'll create a follow-up issue to integrate that into the bot.