### PR TITLE
Stop creating multiple LoL client polling loops every time there is a voiceStateUpdate (#11)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,15 +109,17 @@ client.on('messageCreate', async (message) => {
       } else {
         fs.readdir('./clips', (err, files) => {
           files.forEach((file, index) => {
-              if (file.split(".")[0] === userCommand) {
-                playClip(file, channel, audioPlayer);
-              }
+            if (file.split('.')[0] === userCommand) {
+              playClip(file, channel, audioPlayer);
+            }
           });
         });
       }
     }
   }
 });
+
+let isPollingLolClient = false;
 
 // Event triggered when a user changes voice state - e.g. joins/leaves a channel, mutes/unmutes, etc.
 client.on('voiceStateUpdate', async (oldState, newState) => {
@@ -128,8 +130,9 @@ client.on('voiceStateUpdate', async (oldState, newState) => {
     // Set the channel for the bot to join
     channel = newState.channel as VoiceBasedChannel;
 
-    if (IS_LOL_ANNOUNCER_ENABLED) {
+    if (IS_LOL_ANNOUNCER_ENABLED && !isPollingLolClient) {
       pollCurrentGame(channel, audioPlayer);
+      isPollingLolClient = true;
     }
 
     // Grab the username of the user who joined

--- a/src/league-of-legends-api/poll-current-game.ts
+++ b/src/league-of-legends-api/poll-current-game.ts
@@ -7,7 +7,6 @@ import { Player, RootGameObject } from './types/index';
 const https = require('https');
 
 const LOL_GAME_CLIENT_API = 'https://127.0.0.1:2999/liveclientdata';
-const HALF_SECOND = 500;
 
 const httpsAgent = new https.Agent({
   rejectUnauthorized: false,
@@ -52,5 +51,5 @@ export const pollCurrentGame = async (
       }
       console.log(ERROR_MSG);
     }
-  }, HALF_SECOND);
+  }, 200);
 };


### PR DESCRIPTION
Stop creating multiple LoL client polling loops every time there is a voiceStateUpdate.

This loop should only be created once per "session" with the bot.

Future iterations of this feature will improve the starting logic of the LoL client polling loop, e.g. from recognizing someone in a voice channel is playing LoL.