### PR TITLE
Bot is unable to be disconnect from a `VoiceBasedChannel` with `!gtfo` after restarting the bot server

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,4 +3,3 @@ PORT=8081
 DISCORD_BOT_TOKEN=yourdiscordbottoken
 LEAGUE_OF_LEGENDS_ANNOUNCER_ENABLED=false
 PATH_TO_CLIPS=C:\Path\To\Clips\
-GUILD_ID=TheGuildIdYourBotWillBeIn

--- a/.env.sample
+++ b/.env.sample
@@ -3,3 +3,4 @@ PORT=8081
 DISCORD_BOT_TOKEN=yourdiscordbottoken
 LEAGUE_OF_LEGENDS_ANNOUNCER_ENABLED=false
 PATH_TO_CLIPS=C:\Path\To\Clips\
+GUILD_ID=TheGuildIdYourBotWillBeIn

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -5,6 +5,7 @@ import {
   AudioPlayer,
   AudioPlayerStatus,
   createAudioResource,
+  getVoiceConnection,
   StreamType
 } from '@discordjs/voice';
 import { ActivityType, Presence, VoiceBasedChannel } from 'discord.js';
@@ -35,6 +36,14 @@ export const connectToChannel = async (channel: VoiceBasedChannel) => {
   }
 };
 
+export const disconnectFromChannel = (channel: VoiceBasedChannel | null | undefined) => {
+  // If the channel is defined, kill the connection
+  if (channel) {
+    const connection = getVoiceConnection(channel.guild.id);
+    connection?.destroy();
+  }
+};
+
 export const playClip = async (
   filePathToClip: string,
   channel: VoiceBasedChannel,
@@ -52,6 +61,14 @@ export const playClip = async (
 
   // Return when the audio player signals it's playing
   return entersState(audioPlayer, AudioPlayerStatus.Playing, 5000);
+};
+
+export const stopPlayingClip = async (audioPlayer: AudioPlayer) => {
+  // Stop the audio player
+  audioPlayer.stop(true);
+
+  // Return when the audio player signals it's idle
+  await entersState(audioPlayer, AudioPlayerStatus.Idle, 5000);
 };
 
 export const annouceUnhandledUser = async (

--- a/src/league-of-legends-api/poll-current-game.ts
+++ b/src/league-of-legends-api/poll-current-game.ts
@@ -13,16 +13,10 @@ const httpsAgent = new https.Agent({
   cert: fs.readFileSync('src/league-of-legends-api/riotgames.pem')
 });
 
+// The interval ID for polling the League of Legends Live Game Client API (null if not polling)
+let leagueOfLegendsPollTimer: NodeJS.Timer | null = null;
 let cachedEvents: Event[] = [];
 let cachedGame: RootGameObject | null = null;
-
-export const setCachedEvents = (events: Event[]) => {
-  cachedEvents = events;
-};
-
-export const setCachedGame = (game: RootGameObject | null) => {
-  cachedGame = game;
-};
 
 export const getAllGameData = async () => {
   try {
@@ -32,184 +26,187 @@ export const getAllGameData = async () => {
         httpsAgent
       }
     );
-    setCachedGame(rootGameObject);
+    cachedGame = rootGameObject;
   } catch (err: unknown | AxiosError) {
     const ERROR_MSG = `Error occured when getting game data: ${err}`;
     console.log(ERROR_MSG);
   }
 };
 
-export const pollCurrentGame = (
+export const startPollingLoLGame = (
   channel: VoiceBasedChannel,
   audioPlayer: AudioPlayer,
   pathToClips: string
-): NodeJS.Timer => {
-  console.log('Polling game..');
-  return setIntervalImmediately(async () => {
-    try {
-      if (!cachedGame) {
-        getAllGameData();
-      }
-      const {
-        data: { Events: currentEvents }
-      }: AxiosResponse<RootEventsObject> = await axios.get(`${LOL_GAME_CLIENT_API}/eventdata`, {
-        httpsAgent
-      });
-      if (currentEvents.length > cachedEvents.length) {
-        const newEvent = currentEvents[currentEvents.length - 1];
-        switch (newEvent?.EventName) {
-          case LoLClientEvent.GAME_START: {
-            console.log('game start!');
-            await playClip(`${pathToClips}halo_slayer.mp3`, channel, audioPlayer);
-            break;
-          }
-          case LoLClientEvent.FIRST_BLOOD: {
-            console.log('first blood!');
-            await playClip(`${pathToClips}firstblood.mp3`, channel, audioPlayer);
-            break;
-          }
-          case LoLClientEvent.CHAMPION_KILL: {
-            if (cachedGame) {
-              // Determine who is on the active player's team
-              const activePlayerSummonerName = cachedGame.activePlayer.summonerName;
-              const activePlayerTeam = cachedGame.allPlayers.find(
-                (p) => p.summonerName === activePlayerSummonerName
-              )?.team;
-              const victimSummonerName = newEvent?.VictimName;
-              const victimTeam = cachedGame.allPlayers.find(
-                (p) => p.summonerName === victimSummonerName
-              )?.team;
+) => {
+  if (leagueOfLegendsPollTimer === null) {
+    console.log('Polling game..');
+    leagueOfLegendsPollTimer = setIntervalImmediately(async () => {
+      try {
+        if (!cachedGame) {
+          getAllGameData();
+        }
+        const {
+          data: { Events: currentEvents }
+        }: AxiosResponse<RootEventsObject> = await axios.get(`${LOL_GAME_CLIENT_API}/eventdata`, {
+          httpsAgent
+        });
+        if (currentEvents.length > cachedEvents.length) {
+          const newEvent = currentEvents[currentEvents.length - 1];
+          switch (newEvent?.EventName) {
+            case LoLClientEvent.GAME_START: {
+              console.log('game start!');
+              await playClip(`${pathToClips}halo_slayer.mp3`, channel, audioPlayer);
+              break;
+            }
+            case LoLClientEvent.FIRST_BLOOD: {
+              console.log('first blood!');
+              await playClip(`${pathToClips}firstblood.mp3`, channel, audioPlayer);
+              break;
+            }
+            case LoLClientEvent.CHAMPION_KILL: {
+              if (cachedGame) {
+                // Determine who is on the active player's team
+                const activePlayerSummonerName = cachedGame.activePlayer.summonerName;
+                const activePlayerTeam = cachedGame.allPlayers.find(
+                  (p) => p.summonerName === activePlayerSummonerName
+                )?.team;
+                const victimSummonerName = newEvent?.VictimName;
+                const victimTeam = cachedGame.allPlayers.find(
+                  (p) => p.summonerName === victimSummonerName
+                )?.team;
 
-              if (activePlayerTeam === victimTeam) {
-                console.log('someone on your team died...');
-                // Someone on your team died
-                await playClip(`${pathToClips}bugsplat2.mp3`, channel, audioPlayer);
+                if (activePlayerTeam === victimTeam) {
+                  console.log('someone on your team died...');
+                  // Someone on your team died
+                  await playClip(`${pathToClips}bugsplat2.mp3`, channel, audioPlayer);
+                } else {
+                  console.log('your team killed an enemy!');
+                  // Someone on enemy team died
+                  await playClip(`${pathToClips}PUNCH.mp3`, channel, audioPlayer);
+                }
               } else {
-                console.log('your team killed an enemy!');
-                // Someone on enemy team died
                 await playClip(`${pathToClips}PUNCH.mp3`, channel, audioPlayer);
               }
-            } else {
-              await playClip(`${pathToClips}PUNCH.mp3`, channel, audioPlayer);
+              break;
             }
-            break;
-          }
-          case LoLClientEvent.MULTI_KILL: {
-            if (newEvent.KillStreak === 2) {
-              console.log('doublekill occured!');
-              await playClip(`${pathToClips}halo_doublekill.mp3`, channel, audioPlayer);
-            } else if (newEvent.KillStreak === 3) {
-              console.log('triplekill occured!');
-              await playClip(`${pathToClips}halo_triplekill.mp3`, channel, audioPlayer);
-            } else if (newEvent.KillStreak === 4) {
-              console.log('quadrakill occured!');
-              await playClip(`${pathToClips}halo_killtacular.mp3`, channel, audioPlayer);
-            } else if (newEvent.KillStreak === 5) {
-              console.log('pentakill occured!');
+            case LoLClientEvent.MULTI_KILL: {
+              if (newEvent.KillStreak === 2) {
+                console.log('doublekill occured!');
+                await playClip(`${pathToClips}halo_doublekill.mp3`, channel, audioPlayer);
+              } else if (newEvent.KillStreak === 3) {
+                console.log('triplekill occured!');
+                await playClip(`${pathToClips}halo_triplekill.mp3`, channel, audioPlayer);
+              } else if (newEvent.KillStreak === 4) {
+                console.log('quadrakill occured!');
+                await playClip(`${pathToClips}halo_killtacular.mp3`, channel, audioPlayer);
+              } else if (newEvent.KillStreak === 5) {
+                console.log('pentakill occured!');
+                await playClip(`${pathToClips}halo_unfreakinbelievable.mp3`, channel, audioPlayer);
+              }
+              break;
+            }
+            case LoLClientEvent.ACE: {
+              console.log('ace occured!');
               await playClip(`${pathToClips}halo_unfreakinbelievable.mp3`, channel, audioPlayer);
+              break;
             }
-            break;
-          }
-          case LoLClientEvent.ACE: {
-            console.log('ace occured!');
-            await playClip(`${pathToClips}halo_unfreakinbelievable.mp3`, channel, audioPlayer);
-            break;
-          }
-          case LoLClientEvent.MINIONS_SPAWNING: {
-            console.log('minions spawning...');
-            await playClip(`${pathToClips}minions_laugh.mp3`, channel, audioPlayer);
-            break;
-          }
-          case LoLClientEvent.FIRST_TOWER: {
-            console.log('first turret destroyed!');
-            await playClip(`${pathToClips}illdoitagain.mp3`, channel, audioPlayer);
-            break;
-          }
-          case LoLClientEvent.TURRET_KILLED: {
-            console.log('turret killed!');
-            await playClip(`${pathToClips}illdoitagain.mp3`, channel, audioPlayer);
-            break;
-          }
-          case LoLClientEvent.INHIB_KILLED: {
-            console.log('inhib killed!');
-            await playClip(`${pathToClips}goofy_garsh.mp3`, channel, audioPlayer);
-            break;
-          }
-          case LoLClientEvent.INHIB_RESPAWNED: {
-            console.log('inhib respawned...');
-            break;
-          }
-          case LoLClientEvent.DRAGON_KILLED: {
-            if (newEvent.Stolen === 'True') {
-              console.log('dragon stolen!');
-              await playClip(`${pathToClips}steal_kims_convenience.mp3`, channel, audioPlayer);
-            } else {
-              console.log('dragon killed!');
-              await playClip(`${pathToClips}dracarys.mp3`, channel, audioPlayer);
+            case LoLClientEvent.MINIONS_SPAWNING: {
+              console.log('minions spawning...');
+              await playClip(`${pathToClips}minions_laugh.mp3`, channel, audioPlayer);
+              break;
             }
-            break;
-          }
-          case LoLClientEvent.HERALD_KILLED: {
-            console.log('herald killed!');
-            if (newEvent.Stolen === 'True') {
-              console.log('herald stolen!');
-              await playClip(`${pathToClips}steal_kims_convenience.mp3`, channel, audioPlayer);
-            } else {
+            case LoLClientEvent.FIRST_TOWER: {
+              console.log('first turret destroyed!');
+              await playClip(`${pathToClips}illdoitagain.mp3`, channel, audioPlayer);
+              break;
+            }
+            case LoLClientEvent.TURRET_KILLED: {
+              console.log('turret killed!');
+              await playClip(`${pathToClips}illdoitagain.mp3`, channel, audioPlayer);
+              break;
+            }
+            case LoLClientEvent.INHIB_KILLED: {
+              console.log('inhib killed!');
               await playClip(`${pathToClips}goofy_garsh.mp3`, channel, audioPlayer);
+              break;
             }
-            break;
-          }
-          case LoLClientEvent.BARON_KILLED: {
-            console.log('baron killed!');
-            if (newEvent.Stolen === 'True') {
-              console.log('baron stolen!');
-              await playClip(`${pathToClips}steal_kims_convenience.mp3`, channel, audioPlayer);
-            } else {
-              await playClip(`${pathToClips}goofy_garsh.mp3`, channel, audioPlayer);
+            case LoLClientEvent.INHIB_RESPAWNED: {
+              console.log('inhib respawned...');
+              break;
             }
-            break;
-          }
-          case LoLClientEvent.GAME_END: {
-            if (newEvent?.Result === 'Win') {
-              console.log('victory!');
-              await playClip(`${pathToClips}halo_victory_grunt.mp3`, channel, audioPlayer);
-            } else {
-              console.log('defeat!');
-              await playClip(`${pathToClips}loser_spongebob.mp3`, channel, audioPlayer);
+            case LoLClientEvent.DRAGON_KILLED: {
+              if (newEvent.Stolen === 'True') {
+                console.log('dragon stolen!');
+                await playClip(`${pathToClips}steal_kims_convenience.mp3`, channel, audioPlayer);
+              } else {
+                console.log('dragon killed!');
+                await playClip(`${pathToClips}dracarys.mp3`, channel, audioPlayer);
+              }
+              break;
             }
-            setCachedEvents([]);
-            setCachedGame(null);
-            break;
-          }
-          default: {
-            console.log('unhandled event in switch:', newEvent);
-            break;
+            case LoLClientEvent.HERALD_KILLED: {
+              console.log('herald killed!');
+              if (newEvent.Stolen === 'True') {
+                console.log('herald stolen!');
+                await playClip(`${pathToClips}steal_kims_convenience.mp3`, channel, audioPlayer);
+              } else {
+                await playClip(`${pathToClips}goofy_garsh.mp3`, channel, audioPlayer);
+              }
+              break;
+            }
+            case LoLClientEvent.BARON_KILLED: {
+              console.log('baron killed!');
+              if (newEvent.Stolen === 'True') {
+                console.log('baron stolen!');
+                await playClip(`${pathToClips}steal_kims_convenience.mp3`, channel, audioPlayer);
+              } else {
+                await playClip(`${pathToClips}goofy_garsh.mp3`, channel, audioPlayer);
+              }
+              break;
+            }
+            case LoLClientEvent.GAME_END: {
+              if (newEvent?.Result === 'Win') {
+                console.log('victory!');
+                await playClip(`${pathToClips}halo_victory_grunt.mp3`, channel, audioPlayer);
+              } else {
+                console.log('defeat!');
+                await playClip(`${pathToClips}loser_spongebob.mp3`, channel, audioPlayer);
+              }
+              cachedEvents = [];
+              cachedGame = null;
+              break;
+            }
+            default: {
+              console.log('unhandled event in switch:', newEvent);
+              break;
+            }
           }
         }
-      }
-      setCachedEvents(currentEvents);
-    } catch (err: unknown | AxiosError) {
-      let ERROR_MSG = '';
-      if (axios.isAxiosError(err)) {
-        if (err.cause?.message.includes('ECONNREFUSED')) {
-          ERROR_MSG =
-            'Error getting active game connection. You must be in a live game with LEAGUE_OF_LEGENDS_ANNOUNCER_ENABLED=true in your .env for this to work.';
+        cachedEvents = currentEvents;
+      } catch (err: unknown | AxiosError) {
+        let ERROR_MSG = '';
+        if (axios.isAxiosError(err)) {
+          if (err.cause?.message.includes('ECONNREFUSED')) {
+            ERROR_MSG =
+              'Error getting active game connection. You must be in a live game with LEAGUE_OF_LEGENDS_ANNOUNCER_ENABLED=true in your .env for this to work.';
+          }
         }
+        if (!ERROR_MSG) {
+          ERROR_MSG = `Error occured when getting live game data: ${err}`;
+        }
+        console.log(ERROR_MSG);
       }
-      if (!ERROR_MSG) {
-        ERROR_MSG = `Error occured when getting live game data: ${err}`;
-      }
-      console.log(ERROR_MSG);
-    }
-  }, 200);
+    }, 200);
+  }
 };
 
-export const stopPolling = (timer: NodeJS.Timer | null) => {
-  if (timer) {
-    clearInterval(timer);
+export const stopPollingLoLGame = () => {
+  // Stop polling if there is currently a valid polling timer
+  if (leagueOfLegendsPollTimer) {
+    clearInterval(leagueOfLegendsPollTimer);
     console.log('No longer in game, polling stopped.');
-    setCachedEvents([]);
-    setCachedGame(null);
-    timer = null;
+    cachedEvents = [];
+    cachedGame = null;
+    leagueOfLegendsPollTimer = null;
   }
 };

--- a/src/league-of-legends-api/poll-current-game.ts
+++ b/src/league-of-legends-api/poll-current-game.ts
@@ -44,6 +44,7 @@ export const pollCurrentGame = (
   audioPlayer: AudioPlayer,
   pathToClips: string
 ): NodeJS.Timer => {
+  console.log('Polling game..');
   return setIntervalImmediately(async () => {
     try {
       if (!cachedGame) {
@@ -201,4 +202,14 @@ export const pollCurrentGame = (
       console.log(ERROR_MSG);
     }
   }, 200);
+};
+
+export const stopPolling = (timer: NodeJS.Timer | null) => {
+  if (timer) {
+    clearInterval(timer);
+    console.log('No longer in game, polling stopped.');
+    setCachedEvents([]);
+    setCachedGame(null);
+    timer = null;
+  }
 };


### PR DESCRIPTION
This PR adds the proper `VoiceConnection` reconnection behavior if the bot server gets killed while the bot is in a `VoiceBasedChannel`. It also does a bit of cleaning-up and consolidating of some repeated code blocks.

_helpers.ts_
 - Add new `disconnectFromChannel` and `stopPlayingClip` helper functions

_index.tx_
 - Add correct `VoiceConnection` behavior when the bot is starting up (a `ready` event is emitted)
 - Replace code blocks with new helper functions

_league_of_legends_api/poll-current-game.ts_
 - Move `leagueOfLegendsPollIntervalId` (now named `leagueOfLegendsPollTimer`) into here from `index.ts` as it doesn't need to be exposed
 - Rename `pollCurrentGame` to `startPollingLoLGame`
 - Add null check for `leagueOfLegendsPollTimer` to `startPollingLoLGame` so that it can be called from `index.ts` without having to check if there's already a game being polled
 - Add new `stopPollingLoLGame` function
 - Remove `setCachedEvents` and `setCachedGame` functions as they are no longer being used in other files and are one-liners