### PR TITLE
Create ability to poll LoL client without requiring Discord presence

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,11 @@ import {
   disconnectFromChannel,
   stopPlayingClip
 } from './helpers';
-import { startPollingLoLGame, stopPollingLoLGame } from './league-of-legends-api/poll-current-game';
+import {
+  isPolling,
+  startPollingLoLGame,
+  stopPollingLoLGame
+} from './league-of-legends-api/poll-current-game';
 import { BotCommands } from './types';
 
 const app = express();
@@ -124,6 +128,13 @@ client.on('messageCreate', async (message) => {
         await stopPlayingClip(audioPlayer);
         // Disconnect from the channel
         disconnectFromChannel(channel);
+      } else if (userCommand === BotCommands.POLL) {
+        // Stop polling if already polling. Otherwise, start polling
+        if (isPolling()) {
+          stopPollingLoLGame();
+        } else {
+          startPollingLoLGame(channel, audioPlayer, PATH_TO_CLIPS);
+        }
       } else {
         fs.readdir(PATH_TO_CLIPS, (err, files) => {
           if (err) {

--- a/src/league-of-legends-api/poll-current-game.ts
+++ b/src/league-of-legends-api/poll-current-game.ts
@@ -204,9 +204,13 @@ export const stopPollingLoLGame = () => {
   // Stop polling if there is currently a valid polling timer
   if (leagueOfLegendsPollTimer) {
     clearInterval(leagueOfLegendsPollTimer);
-    console.log('No longer in game, polling stopped.');
+    console.log('Stopping polling..');
     cachedEvents = [];
     cachedGame = null;
     leagueOfLegendsPollTimer = null;
   }
+};
+
+export const isPolling = (): boolean => {
+  return leagueOfLegendsPollTimer !== null;
 };

--- a/src/league-of-legends-api/poll-current-game.ts
+++ b/src/league-of-legends-api/poll-current-game.ts
@@ -28,8 +28,7 @@ export const getAllGameData = async () => {
     );
     cachedGame = rootGameObject;
   } catch (err: unknown | AxiosError) {
-    const ERROR_MSG = `Error occured when getting game data: ${err}`;
-    console.log(ERROR_MSG);
+    console.log(`Error occured when getting all game data: ${err}`);
   }
 };
 
@@ -184,17 +183,7 @@ export const startPollingLoLGame = (
         }
         cachedEvents = currentEvents;
       } catch (err: unknown | AxiosError) {
-        let ERROR_MSG = '';
-        if (axios.isAxiosError(err)) {
-          if (err.cause?.message.includes('ECONNREFUSED')) {
-            ERROR_MSG =
-              'Error getting active game connection. You must be in a live game with LEAGUE_OF_LEGENDS_ANNOUNCER_ENABLED=true in your .env for this to work.';
-          }
-        }
-        if (!ERROR_MSG) {
-          ERROR_MSG = `Error occured when getting live game data: ${err}`;
-        }
-        console.log(ERROR_MSG);
+        console.log(`Error occured when getting game event data: ${err}`);
       }
     }, 200);
   }
@@ -211,6 +200,4 @@ export const stopPollingLoLGame = () => {
   }
 };
 
-export const isPolling = (): boolean => {
-  return leagueOfLegendsPollTimer !== null;
-};
+export const isPolling = (): boolean => leagueOfLegendsPollTimer !== null;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export enum BotCommands {
   GTFO = 'gtfo',
-  CMERE = 'cmere'
+  CMERE = 'cmere',
+  POLL = 'poll'
 }


### PR DESCRIPTION
This PR adds the ability to manually turn on/off polling of the LoL game client without waiting for Discord presence updates. Typing in a `!poll` command will turn off polling if the bot is currently polling, and turn it on if the bot is currently not polling.