### PR TITLE
fix: use 'unknown' folder when no intro folder is found (#53)

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -10,7 +10,7 @@ import {
 } from '@discordjs/voice';
 import { ActivityType, Presence, VoiceBasedChannel } from 'discord.js';
 import discordTTS from 'discord-tts';
-import { LEAGUE_OF_LEGENDS, PATH_TO_CLIPS } from './constants';
+import { EventFiles, LEAGUE_OF_LEGENDS, PATH_TO_CLIPS } from './constants';
 import { Event, RootGameObject } from 'league-of-legends-api/types/index';
 import fs from 'fs';
 import path from 'path';
@@ -74,23 +74,9 @@ export const stopPlayingClip = async (audioPlayer: AudioPlayer) => {
   await entersState(audioPlayer, AudioPlayerStatus.Idle, 5000);
 };
 
-export const announceUnhandledUser = async (
-  channel: VoiceBasedChannel,
-  audioPlayer: AudioPlayer,
-  username: string
-) => {
-  const connection = await connectToChannel(channel);
-
-  connection?.subscribe(audioPlayer);
-
-  const stream = discordTTS.getVoiceStream(`Welcome ${username}. That's a big ass guy!`);
-
-  const audioResource = createAudioResource(stream, {
-    inputType: StreamType.Arbitrary,
-    inlineVolume: true
-  });
-  audioPlayer.play(audioResource);
-};
+// If no intro folder was found for a user, use the unknown folder
+export const announceUnhandledUser = async (channel: VoiceBasedChannel, audioPlayer: AudioPlayer) =>
+  await playRandomClipFromFolder(`${EventFiles.DIS_USER_ENTER}unknown`, channel, audioPlayer);
 
 export const annouceUserIsStreaming = async (
   channel: VoiceBasedChannel,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
 import { AudioPlayerStatus, createAudioPlayer } from '@discordjs/voice';
 import {
   PresenceState,
-  // announceUnhandledUser,
+  announceUnhandledUser,
   annouceUserIsStreaming,
   connectToChannel,
   playClip,
@@ -178,11 +178,9 @@ client.on('voiceStateUpdate', async (oldState, newState) => {
           audioPlayer
         );
 
-        // If no clip was found, announce the user using TTS.
         if (!success) {
           console.log('Unhandled user joined a voice channel. Announcing...');
-          // TODO: this broke, think something got screwed up here with dependency updates looking at error.
-          // await announceUnhandledUser(channel, audioPlayer, usernameNoHash);
+          await announceUnhandledUser(channel, audioPlayer);
         }
       }
     }


### PR DESCRIPTION
Use `unknown` folder within the `channel/enter` directory when an unhandled user enters. I was not able to reproduce the TTS bug, but this fixes it by no longer using TTS for this usecase.